### PR TITLE
feat: add Bun runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,33 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+### Installing Bun
+
+#### On macOS or Linux:
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+#### On Windows:
+1. First, install Windows Subsystem for Linux (WSL):
+   ```powershell
+   # Run in PowerShell as Administrator
+   wsl --install
+   ```
+   After installation, restart your computer.
+
+2. Install Bun in WSL:
+   ```bash
+   # Open WSL terminal and run:
+   curl -fsSL https://bun.sh/install | bash
+   ```
+
+3. For the best experience on Windows:
+   - Use VSCode with the "Remote - WSL" extension
+   - Open your project folder in WSL: `code .`
+   - Run all Bun commands in the WSL terminal
+
+### Running the Development Server
 
 ```bash
 # Using npm
@@ -39,24 +65,54 @@ npm run lint     # Run linting
 
 ### Bun Runtime
 ```bash
+# On macOS/Linux:
 bun run dev:bun    # Start development server with Bun
 bun run build:bun  # Build for production with Bun
 bun run start:bun  # Start production server with Bun
 bun run lint:bun   # Run linting with Bun
+
+# On Windows (via WSL):
+wsl bun run dev:bun    # Start development server
+wsl bun run build:bun  # Build for production
+wsl bun run start:bun  # Start production server
+wsl bun run lint:bun   # Run linting
 ```
 
-Using Bun runtime can provide better performance and faster installation times. To install dependencies with Bun:
+### Installing Dependencies
 ```bash
+# On macOS/Linux:
 bun install
+
+# On Windows (via WSL):
+wsl bun install
 ```
+
+### Troubleshooting on Windows
+
+1. If WSL is not installed:
+   ```powershell
+   # Run in PowerShell as Administrator
+   wsl --install
+   ```
+
+2. If you need to update WSL:
+   ```powershell
+   wsl --update
+   ```
+
+3. Common issues:
+   - If Bun commands aren't working, make sure you're running them in a WSL terminal
+   - If you can't access the development server, check that port forwarding is enabled in WSL
+   - For VSCode integration, install the "Remote - WSL" extension
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
+To learn more about Next.js and Bun, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 - [Bun Documentation](https://bun.sh) - learn about Bun runtime.
+- [WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/) - learn about Windows Subsystem for Linux.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 

--- a/README.md
+++ b/README.md
@@ -5,20 +5,50 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 First, run the development server:
 
 ```bash
+# Using npm
 npm run dev
-# or
+
+# Using yarn
 yarn dev
-# or
+
+# Using pnpm
 pnpm dev
-# or
+
+# Using Node.js runtime
 bun dev
+
+# Using Bun runtime (recommended for better performance)
+bun run dev:bun
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Runtime Options
+
+This project supports both Node.js and Bun runtimes. Here are the available commands:
+
+### Node.js Runtime (Default)
+```bash
+npm run dev      # Start development server
+npm run build    # Build for production
+npm run start    # Start production server
+npm run lint     # Run linting
+```
+
+### Bun Runtime
+```bash
+bun run dev:bun    # Start development server with Bun
+bun run build:bun  # Build for production with Bun
+bun run start:bun  # Start production server with Bun
+bun run lint:bun   # Run linting with Bun
+```
+
+Using Bun runtime can provide better performance and faster installation times. To install dependencies with Bun:
+```bash
+bun install
+```
 
 ## Learn More
 
@@ -26,6 +56,7 @@ To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- [Bun Documentation](https://bun.sh) - learn about Bun runtime.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[install]
+# Use the exact versions specified in package.json
+exact = true
+
+[install.scopes]
+# Configure scope-specific settings if needed
+sportzpoint = { token = "" }  # Add token if needed for private packages

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "dev:bun": "bun --bun run dev",
+    "build:bun": "bun --bun run build",
+    "start:bun": "bun --bun run start",
+    "lint:bun": "bun --bun run lint"
   },
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",
@@ -35,5 +39,8 @@
     "framer-motion": {
       "react": "19.0.0-rc-66855b96-20241106"
     }
-  }
+  },
+  "trustedDependencies": [
+    "sharp"
+  ]
 }


### PR DESCRIPTION
## Changes

- Add Bun runtime support as an optional runtime
- Add Bun-specific npm scripts (dev:bun, build:bun, start:bun, lint:bun)
- Create bunfig.toml for Bun configuration
- Update README with Bun runtime instructions
- Add sharp as trusted dependency for Bun

## Testing

1. Install Bun if not already installed:
```bash
curl -fsSL https://bun.sh/install | bash
```

2. Try running the app with Bun:
```bash
bun install
bun run dev:bun
```

## Notes
- Bun runtime is optional and can be used alongside Node.js
- All existing Node.js commands continue to work as before
- Bun may provide better performance for development and production